### PR TITLE
cannot find <SEGAnalytics.h> with angled brackets, works fine with quotes

### DIFF
--- a/ios/RNAnalytics/RNSegmentIOAnalytics.m
+++ b/ios/RNAnalytics/RNSegmentIOAnalytics.m
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 #import <RCTConvert.h>
-#import <SEGAnalytics.h>
+#import "SEGAnalytics.h"
 #import "RNSegmentIOAnalytics.h"
 
 @implementation RNSegmentIOAnalytics


### PR DESCRIPTION
The library cannot build when trying to import the header file with angled brackets. With quotes this works like a charm though.