### PR TITLE
Update for breaking change in RN 0.40.0

### DIFF
--- a/ios/RNAnalytics/RNSegmentIOAnalytics.h
+++ b/ios/RNAnalytics/RNSegmentIOAnalytics.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2015 Fire Place Inc. All rights reserved.
 //
 
-#import <RCTBridgeModule.h>
+#import <React/RCTBridgeModule.h>
 
 /*
  * React native wrapper of the Segment.com's Analytics iOS SDK

--- a/ios/RNAnalytics/RNSegmentIOAnalytics.m
+++ b/ios/RNAnalytics/RNSegmentIOAnalytics.m
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <RCTConvert.h>
+#import <React/RCTConvert.h>
 #import <SEGAnalytics.h>
 #import "RNSegmentIOAnalytics.h"
 


### PR DESCRIPTION
The headers location for iOS is updated since React Native 0.40.0