### PR TITLE
Fix library paths and update peer dependency to RN 0.40.0

### DIFF
--- a/ios/RNAnalytics/RNSegmentIOAnalytics.h
+++ b/ios/RNAnalytics/RNSegmentIOAnalytics.h
@@ -5,7 +5,7 @@
 //  Copyright (c) 2015 Fire Place Inc. All rights reserved.
 //
 
-#import <RCTBridgeModule.h>
+#import <React/RCTBridgeModule.h>
 
 /*
  * React native wrapper of the Segment.com's Analytics iOS SDK

--- a/ios/RNAnalytics/RNSegmentIOAnalytics.m
+++ b/ios/RNAnalytics/RNSegmentIOAnalytics.m
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <RCTConvert.h>
+#import <React/RCTConvert.h>
 #import <SEGAnalytics.h>
 #import "RNSegmentIOAnalytics.h"
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
   ],
   "homepage": "https://github.com/tonyxiao/react-native-analytics",
   "peerDependencies": {
-    "react-native": ">=0.7.0"
+    "react-native": ">=0.40.0"
   }
 }


### PR DESCRIPTION
In RN 0.40.0 iOS native headers have been moved (see https://github.com/facebook/react-native/releases/tag/v0.40.0)
This leads to build errors, that were already highlighted in #6
This PR fixes the paths and bumps RN peer dependency to 0.40.0