### PR TITLE
Track application lifecycle events.

### DIFF
--- a/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
+++ b/android/src/main/java/com/smore/RNSegmentIOAnalytics/RNSegmentIOAnalyticsModule.java
@@ -37,11 +37,14 @@ public class RNSegmentIOAnalyticsModule extends ReactContextBaseJavaModule {
    https://segment.com/docs/libraries/android/#identify
    */
   @ReactMethod
-  public void setup(String writeKey, Integer flushAt, Boolean shouldUseLocationServices) {
+  public void setup(String writeKey, Integer flushAt, Boolean shouldUseLocationServices, ReadableMap options) {
     if (mAnalytics == null) {
       Context context = getReactApplicationContext().getApplicationContext();
       Builder builder = new Analytics.Builder(context, writeKey);
       builder.flushQueueSize(flushAt);
+      if (options.getBoolean("trackApplicationLifecycleEvents")) {
+        builder.trackApplicationLifecycleEvents();
+      }
 
       if (mDebug) {
         builder.logLevel(Analytics.LogLevel.DEBUG);

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ export default {
      * @param flushAt https://segment.com/docs/libraries/ios/#flushing or https://segment.com/docs/libraries/android/#customizing-the-client
      * @param shouldUseLocationServices https://segment.com/docs/libraries/ios/#location-services
      */
-    setup: function (configKey: string, flushAt: number = 20, shouldUseLocationServices: bool = false) {
-        NativeRNSegmentIOAnalytics.setup(configKey, flushAt, shouldUseLocationServices)
+    setup: function (configKey: string, flushAt: number = 20, shouldUseLocationServices: bool = false, options: ?Object = {}) {
+        NativeRNSegmentIOAnalytics.setup(configKey, flushAt, shouldUseLocationServices, options)
     },
 
     /*

--- a/ios/RNAnalytics/RNSegmentIOAnalytics.m
+++ b/ios/RNAnalytics/RNSegmentIOAnalytics.m
@@ -14,11 +14,12 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(setup:(NSString*)configKey :(NSUInteger)flushAt :(BOOL)shouldUseLocationServices)
+RCT_EXPORT_METHOD(setup:(NSString*)configKey :(NSUInteger)flushAt :(BOOL)shouldUseLocationServices :(NSDictionary *)options)
 {
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:configKey];
     configuration.flushAt = flushAt;
     configuration.shouldUseLocationServices = shouldUseLocationServices;
+    configuration.trackApplicationLifecycleEvents = options[@"trackApplicationLifecycleEvents"];
     [SEGAnalytics setupWithConfiguration:configuration];
 }
 


### PR DESCRIPTION
Add option to enable application lifecycle events tracking.
The third argument to `setup` method is added as a Map, for future extensibility.
Tested on both iOS and Android.