### PR TITLE
Chore: update analytics lib versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.19.+'
-    compile 'com.segment.analytics.android:analytics:4+'
+    compile 'com.segment.analytics.android:analytics:4.3.0'
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,6 +9,6 @@ target 'RNSegmentIOAnalytics' do
     'RCTNetwork',
     'RCTWebSocket',
   ]
-  pod 'Analytics', '~> 3.2'
+  pod 'Analytics', '~> 3.6'
 
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Analytics (3.2.0)
+  - Analytics (3.6.10)
   - React/Core (0.26.3)
   - React/RCTNetwork (0.26.3):
     - React/Core
@@ -7,19 +7,23 @@ PODS:
     - React/Core
 
 DEPENDENCIES:
-  - Analytics (~> 3.2)
+  - Analytics (~> 3.6)
   - React/Core (from `../node_modules/react-native`)
   - React/RCTNetwork (from `../node_modules/react-native`)
   - React/RCTWebSocket (from `../node_modules/react-native`)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Analytics
 
 EXTERNAL SOURCES:
   React:
     :path: "../node_modules/react-native"
 
 SPEC CHECKSUMS:
-  Analytics: 8f77915b931d8f4b920deab2a6710303ced611ed
-  React: 82b64b37b7ad5895b902b33bc7d5a49dbc22793e
+  Analytics: 63744ad4afa65c3bcdcdb7a94b62515bde5b3900
+  React: 04b2afd71b1b2b638f85d9dab099592d87b5f264
 
-PODFILE CHECKSUM: c7b7ce31cbdc1313a18a312b7d58661adab28e59
+PODFILE CHECKSUM: ce507bdf041b43bc43089bee32fe08fc5b8f363b
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.5.3

--- a/ios/RNSegmentIOAnalytics.xcodeproj/project.pbxproj
+++ b/ios/RNSegmentIOAnalytics.xcodeproj/project.pbxproj
@@ -99,7 +99,6 @@
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
 				58B511D91A9E6C8500147676 /* CopyFiles */,
-				62F1C12258A16A4923216034 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -142,34 +141,22 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		62F1C12258A16A4923216034 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RNSegmentIOAnalytics/Pods-RNSegmentIOAnalytics-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		F124868C6CA48D633754D72E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RNSegmentIOAnalytics-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
this updates the segment Analytics lib to use the latest version on both iOS and Android. it also specifies the Android version explicitly, rather than allowing anything within v4 (its pinned to the latest, and having the `:4+` as they did is a lint/correctness issue according to android)